### PR TITLE
Fix maxOrders initialization

### DIFF
--- a/NEAT.js
+++ b/NEAT.js
@@ -24,12 +24,12 @@ class Indicator {
     this.candles = [];
     this.normalizedCandles = [];
     this.maxOrders = {
-      high: 0,
-      low: 0,
-      close: 0,
-      open: 0,
-      volume: 0,
-      trades: 0
+      high: Number.NEGATIVE_INFINITY,
+      low: Number.NEGATIVE_INFINITY,
+      close: Number.NEGATIVE_INFINITY,
+      open: Number.NEGATIVE_INFINITY,
+      volume: Number.NEGATIVE_INFINITY,
+      trades: Number.NEGATIVE_INFINITY
     };
 
     this.trainConfig = {


### PR DESCRIPTION
You initialize every element in maxOrders to 0, but when you are calculating the scaling factor for trade pairs that have a low relative value it can and will happen that the maxOrder is negative, and when you max(0, order) you'll never overwrite the 0.